### PR TITLE
Allow for setting the transport name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Basic transport that works just like all other winston transports. Sends logged messages to a specified slack chat channel
 
 First install winston...
-    
+
     $ npm install winston
 
 Then install winston-bishop-slack
@@ -16,11 +16,12 @@ Then install winston-bishop-slack
 * **icon_url:** *avatar of the message 'sender' as it appears in slack*
 * **channel:** *channel on which the sent message will appear in slack*
 * **username:** *name displayed in the chat channel. default "Winston Bishop"*
+* **name:** *name of the transport. default "slack"*
 
 <code>
     var winston = require('winston');
     var slack = require('winston-bishop-slack').Slack;
-    
+
     winston.add(slack, {
       webhook_url: "https://hooks.slack.com/services/...",
       icon_url: "https://stagefisher.s3.amazonaws.com/images/character/image/519b31da5bf1614f8100000e/Winston-Bishop-New_Girl.jpg",
@@ -41,8 +42,8 @@ Then install winston-bishop-slack
         }]}
       }
     })
-  
-    winston.error('Ferguson Ran Away!', { detail: "He was last seen at 3pm on Tuesday" }, 
+
+    winston.error('Ferguson Ran Away!', { detail: "He was last seen at 3pm on Tuesday" },
       function(err, res) {
         console.log('Finished 3: (error=%s)', JSON.stringify(err, null, 2));
       }
@@ -50,4 +51,3 @@ Then install winston-bishop-slack
 </code>
 
 ![winston](https://cldup.com/ZcEghxatuM-3000x3000.png "Looks like this...")
-

--- a/lib/winston-slack.js
+++ b/lib/winston-slack.js
@@ -10,12 +10,13 @@ var Slack = exports.Slack = function (options) {
   }
   else {
       this.webhook_url     = options.webhook_url;
-      this.channel         = options.channel;      
+      this.channel         = options.channel;
       this.icon_url        = options.icon_url || "https://cldup.com/9M--n6m2F6-3000x3000.jpeg";
       this.username        = options.username || "Winston Bishop";
       this.level           = options.level    || 'info';
       this.silent          = options.silent   || false;
       this.raw             = options.raw      || false;
+      this.name            = options.name     || 'slack'
       this.customFormatter = options.customFormatter;
 
       //- Enabled loging of uncaught exceptions
@@ -25,7 +26,6 @@ var Slack = exports.Slack = function (options) {
 
 util.inherits(Slack, winston.Transport);
 winston.transports.Slack = Slack;
-Slack.prototype.name = 'slack'
 
 Slack.prototype.log = function (level, msg, meta, callback) {
   //- Use custom formatter for message if set


### PR DESCRIPTION
We use different channels in slack for different log levels. However, with the current setup you'd have to hook on the `'slack'` transport twice which Winston does not allow, so you get an error. 

Now you can provide it in the options